### PR TITLE
Do a r10k run at every start

### DIFF
--- a/webhook/docker-entrypoint.d/run_r10k.sh
+++ b/webhook/docker-entrypoint.d/run_r10k.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/bin/r10k deploy environment --modules


### PR DESCRIPTION
... so the code directory isn't empty at the first start of the container and actually if the container hasn't been used for a long.